### PR TITLE
Add support for when GRIDUNIT is provided explicitly in grdecl

### DIFF
--- a/src/InputParser/parser.jl
+++ b/src/InputParser/parser.jl
@@ -294,7 +294,7 @@ function parse_grdecl_file(filename;
     )
     outer_data = Dict{String, Any}()
     data = new_section(outer_data, :GRID)
-    parse_data_file!(outer_data, filename, data; kwarg...)
+    parse_data_file!(outer_data, filename, data; input_units = input_units, kwarg...)
     if !ismissing(actnum_path)
         parse_data_file!(outer_data, actnum_path, data; input_units = input_units, kwarg...)
     end


### PR DESCRIPTION
This pull request includes a change to the `parse_grdecl_file` function in the `src/InputParser/parser.jl` file to ensure that `input_units` is passed as a keyword argument when calling `parse_data_file!`.

* [`src/InputParser/parser.jl`](diffhunk://#diff-9af545c961bd0b1f8feed8a8c6580b763b74bf9abaf3d316209ff5221edc4e18L297-R297): Modified the `parse_grdecl_file` function to include `input_units` as a keyword argument in the `parse_data_file!` calls.