### PR TITLE
Fix parallel segments crash in find_crossing_node

### DIFF
--- a/src/CornerPointGrid/processing_utils.jl
+++ b/src/CornerPointGrid/processing_utils.jl
@@ -354,12 +354,21 @@ function find_crossing_node(x1, x2, x3, x4)
     axb = cross(a, b)
     cxb = cross(c, b)
     nrm = norm(axb, 2)^2
-    if nrm == 0.0 
-        @warn "Bad intercept: $((x1, x2)) to $((x3, x4))" a b c
-        error()
+    if nrm > 0.0
+        x_intercept = x1 + a*(dot(cxb, axb)/nrm)
+        return x_intercept
     end
-    x_intercept = x1 + a*(dot(cxb, axb)/nrm)
-    return x_intercept
+    # Degenerate: segments are parallel (same direction in 3D). This occurs
+    # with vertical pillars from cpgrid_from_horizons when a ZCORN transform
+    # shifts both endpoints by the same throw, keeping direction vectors
+    # identical. Reduce to 1D crossing in z-parameter space:
+    #   Segment A: z(t) = z1 + t*(z2-z1)
+    #   Segment B: z(t) = z3 + t*(z4-z3)
+    # Solve for t where A and B cross in z.
+    z1, z2, z3, z4 = x1[3], x2[3], x3[3], x4[3]
+    denom = (z2 - z1) - (z4 - z3)
+    t = abs(denom) < 1e-12 ? 0.5 : clamp((z3 - z1) / denom, 0.0, 1.0)
+    return x1 + t * a
 end
 
 function cpgrid_get_or_add_crossing_node!(extra_node_lookup, nodes, pt)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -238,6 +238,22 @@ import Jutul: number_of_cells, number_of_boundary_faces, number_of_faces, conver
         m = mesh_from_grid_section(gs)
         @test number_of_cells(m) == (nx-1)*(ny-1)*(l1 + l2) - l1 - l2
     end
+    @testset "cpgrid_diagonal_fault_crossing" begin
+        # Diagonal fault with ZCORN throw creates parallel pillar segments
+        # in find_crossing_node (issue #47). Previously crashed with error().
+        nx = 21
+        ny = 21
+        xrng = range(0.0, 200.0, nx)
+        yrng = range(0.0, 200.0, ny)
+        depths = [fill(2000.0, nx, ny), fill(2025.0, nx, ny), fill(2050.0, nx, ny)]
+        function diagonal_fault(x, y, z, x_c, y_c, i, j, k)
+            on_hanging_wall = (x_c - 100.0) + (y_c - 100.0) > 0
+            return on_hanging_wall ? z - 10.0 : z
+        end
+        gs = cpgrid_from_horizons(xrng, yrng, depths; transforms = [diagonal_fault])
+        m = mesh_from_grid_section(gs)
+        @test number_of_cells(m) == (nx - 1) * (ny - 1) * 2
+    end
 end
 
 include("ixparser.jl")


### PR DESCRIPTION
## Summary

- **Fixes #47**: `find_crossing_node` crashes with `error()` when two face-boundary line segments are parallel in 3D (cross product norm = 0)
- When segments are parallel (`nrm ≈ 0`), falls back to 1D crossing in z-parameter space instead of crashing
- Adds test case: diagonal fault transform on a 20×20 grid that previously triggered the crash

## Context

This occurs when using `cpgrid_from_horizons` with ZCORN transforms that create discontinuities at oblique fault angles. Vertical pillars have constant (x, y) coordinates, so two segments connecting the same pillar pair share the same direction vector — making `cross(a, b) = 0`. Cardinal-aligned faults (0°, 90°) don't trigger this because fault-face segments connect pillars with different (x, y) positions.

## The fix

When `nrm == 0` (parallel segments), reduce to 1D crossing in z-parameter space:
- Segment A: `z(t) = z1 + t*(z2-z1)`
- Segment B: `z(t) = z3 + t*(z4-z3)`
- Solve for `t` where A and B cross in z, clamp to [0, 1]

If the z-spans are also identical (`denom ≈ 0`), use midpoint (`t = 0.5`).

## Test plan

- [x] New test: 21×21 grid with 10m-throw diagonal fault — verifies mesh builds successfully with expected cell count
- [x] Full existing test suite passes (8239 + 552543 tests)
- [x] Tested across 13 fault angles × 2 grid sizes (26 configurations) in our downstream project