### PR TITLE
Handle sheared boundary columns in vertical-face overlap

### DIFF
--- a/src/CornerPointGrid/processing.jl
+++ b/src/CornerPointGrid/processing.jl
@@ -487,7 +487,7 @@ function grid_from_primitives(primitives; nnc = missing, pinch = missing)
                     end
                     if col_is_bnd || pair_is_bnd
                         # Boundary if we are on a boundary column or one of the cells connected to the face is a boundary
-                        add_vertical_face_from_overlap!(extra_node_lookup, F_bnd, nodes, cell_pair, overlap, l1, l2, node_buffer, pair_is_bnd)
+                        add_vertical_face_from_overlap!(extra_node_lookup, F_bnd, nodes, cell_pair, overlap, l1, l2, node_buffer, pair_is_bnd, is_boundary_col = col_is_bnd)
                     else
                         add_vertical_face_from_overlap!(extra_node_lookup, F_interior, nodes, cell_pair, overlap, l1, l2, node_buffer)
                     end

--- a/src/CornerPointGrid/processing_utils.jl
+++ b/src/CornerPointGrid/processing_utils.jl
@@ -80,7 +80,7 @@ function cell_top_bottom!(out, cells, line1, line2; check = false)
     return out
 end
 
-function add_vertical_face_from_overlap!(extra_node_lookup, F, nodes, cell_pair, overlap, l1, l2, node_pos, reversed = false)
+function add_vertical_face_from_overlap!(extra_node_lookup, F, nodes, cell_pair, overlap, l1, l2, node_pos, reversed = false; is_boundary_col = false)
     resize!(node_pos, 0)
     function global_node_index(l, local_node)
         return l.nodes[local_node]
@@ -118,6 +118,13 @@ function add_vertical_face_from_overlap!(extra_node_lookup, F, nodes, cell_pair,
     if cell_a == cell_b
         # If both cells are the same, we are dealing with a mirrored
         # column pair at the boundary.
+        cell_a = 0
+    elseif is_boundary_col
+        # Sheared boundary column: the two boundary pillars land in different active
+        # cells (a within-column offset reaching the domain edge), so neither side is an
+        # inactive/ghost cell. It is still an external boundary face, so mark one side as
+        # outside and insert it as a boundary face owned by cell_b rather than a
+        # (nonexistent) interior connection between two active cells.
         cell_a = 0
     end
     if length(node_pos) > 2


### PR DESCRIPTION
## Problem

`mesh_from_grid_section` asserts on corner-point grids whose **boundary columns are sheared** — i.e. a within-column vertical offset that reaches the domain edge (for example a fault throw sampled onto the pillar lattice):

```
AssertionError: cell pair (i, j) is not on boundary
  insert_boundary_face!        @ CornerPointGrid/processing.jl
  add_vertical_face_from_overlap! @ CornerPointGrid/processing_utils.jl
  grid_from_primitives → mesh_from_zcorn_and_coord → mesh_from_grid_section
```

In `grid_from_primitives`, a vertical-face overlap on a boundary column is routed to the boundary-face inserter, which requires exactly one side of the pair to be an inactive/ghost cell. `add_vertical_face_from_overlap!` only neutralized this for the *mirrored* case (`cell_a == cell_b → 0`), which covers flat boundary columns. When the two boundary pillars of a column land in **two different active cells** (a within-column offset at the edge), neither side is a boundary, the reset never fires, and `insert_boundary_face!` asserts.

This is the same fault-overlap machinery as #47/#48, but a different function — `find_crossing_node` (fixed in #48) is fine; this is `insert_boundary_face!`/`add_vertical_face_from_overlap!`.

## Fix

Generalize the boundary reset: on a boundary column with two distinct active cells, mark one side as outside so the external face is inserted as a boundary face (owned by `cell_b`) rather than a nonexistent interior connection between two active cells. The affected boundary faces are **kept**, so the mesh stays watertight (it is not a drop/skip).

The change is small (2 + 9 lines, no reformatting) and the existing test suite passes, including the `check_normals` boundary/interior normal checks.

## Reproducer / context

This surfaced in a downstream package that builds corner-point grids from geological models with fault throw — the displacement produces sheared boundary columns for a large fraction of realizations (geometry-insensitive, ~1 in 4). I have a serialized grid section that reproduces it standalone via `mesh_from_grid_section`; happy to add it (or a minimal synthetic equivalent) as a regression test if you'd like — just let me know the form you prefer.
